### PR TITLE
Fix outdated links in documentation

### DIFF
--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,1 +1,1 @@
-library.arabianvacc.com
+library.vatsim-arabian.com

--- a/docs/getting_started/audio.md
+++ b/docs/getting_started/audio.md
@@ -9,7 +9,7 @@ There are two audio clients available for use on VATSIM:
       - [Download Audio for VATSIM](https://audio.vatsim.net/assets/files/audio-for-vatsim-12376d020a19027dcad44bb0be1a2ca7.msi)  
 
 - **Track Audio**  
-      - [Download Track Audio](https://github.com/pierr3/TrackAudio/releases/tag/1.3.0-beta.4)  
+      - [Download Track Audio](https://github.com/pierr3/TrackAudio/releases/tag/1.4.0-beta.4)  
 
 ---
 

--- a/docs/getting_started/starting_atc_training.md
+++ b/docs/getting_started/starting_atc_training.md
@@ -21,7 +21,7 @@ VATSIM follows a system of graduated ratings that determine the positions you ca
 
 > **Important:** You must be a **resident of the Arabian vACC** before beginning ATC training.
 
-Check your status and how to join here: [Joining Arabian](https://library.arabianvacc.com/getting_started/joining_arabian/)
+Check your status and how to join here: [Joining Arabian](https://library.vatsim-arabian.com/getting_started/joining_arabian/)
 
 > Joining may take up to 72 hours. Transferring out will remove you from our waiting list and cancel your training eligibility.
 
@@ -31,9 +31,9 @@ Check your status and how to join here: [Joining Arabian](https://library.arabia
 
 Before you can observe or train, install the following:
 
-- [Euroscope & Sector Files](https://library.arabianvacc.com/getting_started/euroscope/)
-- [An Audio for VATSIM Client](https://library.arabianvacc.com/getting_started/audio/)
-- [vATIS](https://library.arabianvacc.com/getting_started/vatis/)
+- [Euroscope & Sector Files](https://library.vatsim-arabian.com/getting_started/euroscope/)
+- [An Audio for VATSIM Client](https://library.vatsim-arabian.com/getting_started/audio/)
+- [vATIS](https://library.vatsim-arabian.com/getting_started/vatis/)
 
 🎥 **Watch this video guide** on how to observe on the network:  
 [Arabian vACC - Controller Software & Observation Guide](https://www.youtube.com/watch?v=ycCieiy0ufc)
@@ -58,7 +58,7 @@ Once you're in the Discord and meet the above:
 ## 📘 Read the ATC Training Policy
 
 We highly recommend reviewing the full policy:  
-[Arabian vACC ATC Training Policy](https://library.arabianvacc.com/policies/atc_training/general/)
+[Arabian vACC ATC Training Policy](https://library.vatsim-arabian.com/policies/atc_training/general/)
 
 ---
 
@@ -67,7 +67,7 @@ We highly recommend reviewing the full policy:
 After your ticket is submitted:
 
 1. You will be added to the **S1 Rating Waiting List** along with a designated **Training Aerodrome**.
-2. You will be enrolled in the **S1 Moodle Course**: [Arabian vACC Moodle](https://moodle.arabianvacc.com)
+2. You will be enrolled in the **S1 Moodle Course**: [Arabian vACC Moodle](https://moodle.vatsim-arabian.com)
 3. Complete all course content and progress tests.
 4. Pass the **MENA S1 Theory Exam**: [MENA Theoretical Exam Platform](https://exams.vatsim.me/)
 
@@ -84,14 +84,14 @@ After verification, you will:
 1. Able to request enrollment in the **S1 Training Plan** via [Hayya](https://hayya.vatsim.me/).
 2. Be able to **schedule 1-on-1 sessions** with a mentor or instructor once approved in the **S1 Training Plan**.
 
-📖 Prepare using the documentation for your aerodrome at the [Arabian vACC Library](https://library.arabianvacc.com/).  
+📖 Prepare using the documentation for your aerodrome at the [Arabian vACC Library](https://library.vatsim-arabian.com/).  
 Failure to come prepared may result in your session being cancelled.
 
 ---
 
 ## 🧪 Final Exam & S1 Rating
 
-Once all sessions in the [S1 Training Syllabus](https://library.arabianvacc.com/policies/atc_training/s1/) are complete, you will:
+Once all sessions in the [S1 Training Syllabus](https://library.vatsim-arabian.com/policies/atc_training/s1/) are complete, you will:
 
 - Take a final **practical exam** on the Sweatbox simulator server.
 
@@ -106,7 +106,7 @@ After your S1 rating, you may work toward:
 - **Tier-1 Dubai DEL/GND Endorsement**
 - **Tier-2 AFIS Endorsement**
 
-Requirements are outlined in the [ATC Training Policy](https://library.arabianvacc.com/policies/atc_training/general/).
+Requirements are outlined in the [ATC Training Policy](https://library.vatsim-arabian.com/policies/atc_training/general/).
 
 ---
 

--- a/docs/getting_started/training_reform.md
+++ b/docs/getting_started/training_reform.md
@@ -35,24 +35,24 @@ To solve this:
 ## 📚 Essential Resources  
 
 - **Getting Started Guide (OBS → S1):**  
-  👉 [Getting Started - ATC Training](https://library.arabianvacc.com/getting_started/starting_atc_training/)<br>Every step to begin your ATC journey is explained here, including how to become a **resident of the vACC**. Please read this guide carefully before asking questions.  
+  👉 [Getting Started - ATC Training](https://library.vatsim-arabian.com/getting_started/starting_atc_training/)<br>Every step to begin your ATC journey is explained here, including how to become a **resident of the vACC**. Please read this guide carefully before asking questions.  
 
 
 - **ATC Training Policy:**  
-  👉 [ATC Training Policy](https://library.arabianvacc.com/policies/atc_training/general/)<br>This policy covers expressions of interest, waiting lists, active training, airports, CTAs/TMAs, ACCs, progression requirements, endorsements (Tier-1 & upcoming Tier-2), and activity requirements.  
+  👉 [ATC Training Policy](https://library.vatsim-arabian.com/policies/atc_training/general/)<br>This policy covers expressions of interest, waiting lists, active training, airports, CTAs/TMAs, ACCs, progression requirements, endorsements (Tier-1 & upcoming Tier-2), and activity requirements.  
 
 
 - **What to Expect During Sessions:**  
-    - [S1](https://library.arabianvacc.com/policies/atc_training/s1/)  
-    - [S2](https://library.arabianvacc.com/policies/atc_training/s2/)  
-    - [S3](https://library.arabianvacc.com/policies/atc_training/s3/)  
-    - [C1](https://library.arabianvacc.com/policies/atc_training/c1/)  
+    - [S1](https://library.vatsim-arabian.com/policies/atc_training/s1/)  
+    - [S2](https://library.vatsim-arabian.com/policies/atc_training/s2/)  
+    - [S3](https://library.vatsim-arabian.com/policies/atc_training/s3/)  
+    - [C1](https://library.vatsim-arabian.com/policies/atc_training/c1/)  
 
 ---
 
 ## 🖥️ Self-Study Courses & Seminars  
 
-- **OBS → S1 Controllers** will have access to a new **Moodle self-study course** (👉 moodle.arabianvacc.com).  
+- **OBS → S1 Controllers** will have access to a new **Moodle self-study course** (👉 moodle.vatsim-arabian.com).  
     - Access instructions are in the **Getting Started Guide** (please read it carefully).  
     - The course includes several modules covering most theoretical knowledge.  
     - Each module has **progress checks** to ensure proper understanding.  
@@ -92,22 +92,22 @@ For those going **OBS → S1**, the majority of the work is now in your hands wi
 ## 📝 Reminders for All Controllers  
 
 - **Euroscope User Guide (since Dec 2024):**  
-  👉 [Getting Started, Euroscope](https://library.arabianvacc.com/getting_started/euroscope/)
+  👉 [Getting Started, Euroscope](https://library.vatsim-arabian.com/getting_started/euroscope/)
 
 - **Audio Client User Guide (since Dec 2024):**  
-  👉 [Getting Started, Audio Client](https://library.arabianvacc.com/getting_started/audio/)
+  👉 [Getting Started, Audio Client](https://library.vatsim-arabian.com/getting_started/audio/)
 
 - **vATIS Client User Guide (since Dec 2024):**  
-  👉 [Getting Started, vATIS](https://library.arabianvacc.com/getting_started/vatis/)
+  👉 [Getting Started, vATIS](https://library.vatsim-arabian.com/getting_started/vatis/)
 
 - **vATIS Update Requirement:**  
   All controllers must update their vATIS client, refresh their profiles to the latest automatic ones: 👉 [Arabian vACC, vATIS Profiles](https://github.com/Arabian-vACC/vATIS-Profiles/releases) and ensure correct **Airport Conditions & NOTAMs** are selected (*looking at you, Hamad controllers – “HIRO INFORCE”*).  
 
 - **Controller Operations Policy:**  
-  👉 [Controller Operations Policy](https://library.arabianvacc.com/policies/atc_operations/controller_operations_policy/)<br>Covers connection procedures, minimum session time, Discord presence, relief callsigns, and more.  
+  👉 [Controller Operations Policy](https://library.vatsim-arabian.com/policies/atc_operations/controller_operations_policy/)<br>Covers connection procedures, minimum session time, Discord presence, relief callsigns, and more.  
 
 - **General Marketing Policy (released Aug 18th):**  
-  👉 [Marketing Policy](https://library.arabianvacc.com/policies/marketing/general/#event-signup)<br>Outlines **Event Rostering rules and regulations**.  
+  👉 [Marketing Policy](https://library.vatsim-arabian.com/policies/marketing/general/#event-signup)<br>Outlines **Event Rostering rules and regulations**.  
 
 ---
 

--- a/docs/getting_started/transfer_and_visiting.md
+++ b/docs/getting_started/transfer_and_visiting.md
@@ -101,6 +101,6 @@ To continue holding visiting privileges in the Arabian vACC, controllers must:
 ## Transfer Process
 To apply for a **transfer** to the **Arabian vACC**, please follow the step-by-step instructions provided in the official guide:
 
-👉 [**Joining the Arabian vACC**](https://library.arabianvacc.com/getting_started/joining_arabian/)
+👉 [**Joining the Arabian vACC**](https://library.vatsim-arabian.com/getting_started/joining_arabian/)
 
 This guide will walk you through the entire process, from checking your current assignment to submitting a formal transfer request. Be sure to read it carefully to ensure a smooth transition.

--- a/docs/policies/atc_operations/controller_operations_policy.md
+++ b/docs/policies/atc_operations/controller_operations_policy.md
@@ -110,7 +110,7 @@ Sessions under 30 minutes will not be counted toward the controller's quarterly 
 
 ### 7.1 General
 
-The [Arabian vACC ATC Booking System (Coming Soon™)](https://arabianvacc.com) allows rated Resident or Visitor controllers to book ATC positions within the vACC. Bookings are also submitted to the VATSIM ATC system.
+The [Arabian vACC ATC Booking System (Coming Soon™)](https://vatsim-arabian.com) allows rated Resident or Visitor controllers to book ATC positions within the vACC. Bookings are also submitted to the VATSIM ATC system.
 
 ### 7.2 Booking a Position
 

--- a/docs/policies/atc_training/general.md
+++ b/docs/policies/atc_training/general.md
@@ -48,17 +48,17 @@ Sector files for each FIR can be downloaded from the [AeroNav GNG website](https
 - [Muscat FIR (OOMM)](https://files.aero-nav.com/OOMM)
 - [Emirates FIR (OMAE)](https://files.aero-nav.com/OMAE)
 
-A detailed setup guide for installing Euroscope and the Arabian vACC sector files is available under the "Controller Software Setup" section of the [Arabian vACC Library](https://library.arabianvacc.com/foundations/).
+A detailed setup guide for installing Euroscope and the Arabian vACC sector files is available under the "Controller Software Setup" section of the [Arabian vACC Library](https://library.vatsim-arabian.com/foundations/).
 
 ### 2.2.2 Audio Client(s)
 To communicate with pilots while controlling on the network, you must install an approved Audio for VATSIM client. Supported options include [Audio for VATSIM](https://audio.vatsim.net/docs/atc/euroscope) and [TrackAudio](https://github.com/pierr3/TrackAudio/releases/tag/1.3.1).
 
-A step-by-step setup guide for these audio clients can be found in the "Controller Software Setup" section of the [Arabian vACC Library](https://library.arabianvacc.com/foundations/).
+A step-by-step setup guide for these audio clients can be found in the "Controller Software Setup" section of the [Arabian vACC Library](https://library.vatsim-arabian.com/foundations/).
 
 ### 2.2.3 vATIS Client
 To provide pilots with up-to-date aerodrome operational information, you will need the [vATIS Client](https://vatis.app/).
 
-A detailed setup guide for vATIS is available in the "Controller Software Setup" section of the [Arabian vACC Library](https://library.arabianvacc.com/foundations/).
+A detailed setup guide for vATIS is available in the "Controller Software Setup" section of the [Arabian vACC Library](https://library.vatsim-arabian.com/foundations/).
 
 ### 2.2.4 Discord
 Discord serves as the primary communication platform for the Arabian vACC and is used for a range of purposes, including:
@@ -182,7 +182,7 @@ The ATC Training Department Director reserves the right to remove a member from 
 All forfeiture decisions will be made in alignment with the broader goals of maintaining fairness, efficiency, and high standards across the training program.
 
 # 5. Self-Study
-Students are expected to engage with the theoretical content provided in the [Arabian vACC Library](https://library.arabianvacc.com) outside of their scheduled mentoring sessions. This includes, but is not limited to, reviewing assigned readings, practicing relevant skills, and deepening their understanding of core concepts. Mentors and instructors may also suggest additional resources or encourage observation of experienced controllers.
+Students are expected to engage with the theoretical content provided in the [Arabian vACC Library](https://library.vatsim-arabian.com) outside of their scheduled mentoring sessions. This includes, but is not limited to, reviewing assigned readings, practicing relevant skills, and deepening their understanding of core concepts. Mentors and instructors may also suggest additional resources or encourage observation of experienced controllers.
 
 After each mentoring session, mentors and instructors will provide comprehensive feedback. It is the student's responsibility to carefully review these reports and address any areas highlighted by the mentor for improvement. This may involve independent study on certain topics or revisiting specific techniques. Research consistently shows that students who actively engage with feedback and make necessary adjustments tend to progress more rapidly through training and perform better on exams.
 
@@ -418,7 +418,7 @@ Controllers who meet all the requirements above must submit a support ticket to 
 If a controller applies for a DEL/GND endorsement and later obtains their S2 rating, they will need to go through the same process again to obtain the next Tier 1 Dubai endorsement for TWR. Similarly, controllers holding an S3 rating and seeking the Tier 1 Dubai endorsement for TMA will need to follow the same process.
 
 ### 12.6.3 Theoretical Course & Examination
-The theoretical course for the specific Tier 1 Dubai endorsement is available through the [Arabian vACC Moodle](https://moodle.arabianvacc.com/) platform. This course includes all relevant resources required to understand and operate the Dubai positions effectively.
+The theoretical course for the specific Tier 1 Dubai endorsement is available through the [Arabian vACC Moodle](https://moodle.vatsim-arabian.com/) platform. This course includes all relevant resources required to understand and operate the Dubai positions effectively.
 
 Access to the theoretical course will only be granted once the controller has met all eligibility criteria outlined above and has formally requested access. Access to the theoretical exam will be granted a week after being enrolled on the relevant Dubai Moodle course.
 
@@ -485,7 +485,7 @@ Before a controller is eligible to complete a Tier 2 AFIS endorsement, they must
 If controllers have met all the requirements listed above, they must submit a support ticket to the Arabian vACC ATC Training Department to express their interest in obtaining the AFIS endorsement. 
 
 ### 12.7.2 Theoretical Course & Examination
-The theoretical course for AFIS operations is available through the [Arabian vACC Moodle](https://moodle.arabianvacc.com/) platform. This course includes all relevant resources required to understand and operate AFIS positions effectively.
+The theoretical course for AFIS operations is available through the [Arabian vACC Moodle](https://moodle.vatsim-arabian.com/) platform. This course includes all relevant resources required to understand and operate AFIS positions effectively.
 
 Access to the theoretical examination will only be granted once the controller has met all eligibility criteria outlined above and has formally requested access.
 
@@ -521,7 +521,7 @@ If controllers have met all the requirements listed above, they must submit a su
 If a controller applies for a TWR endorsement and later obtains their S2 rating, they will need to go through the same process again to obtain the next Tier 2 military endorsement for APP. Similarly, controllers holding a C1 rating and seeking the Tier 2 military endorsement for CTR will need to follow the same process.
 
 ### 12.8.2 Theoretical Course & Examination
-The theoretical course for military operations is available through the [Arabian vACC Moodle](https://moodle.arabianvacc.com) platform. This course contains all essential materials required to understand and operate military positions effectively within the Arabian vACC.
+The theoretical course for military operations is available through the [Arabian vACC Moodle](https://moodle.vatsim-arabian.com) platform. This course contains all essential materials required to understand and operate military positions effectively within the Arabian vACC.
 
 Access to the theoretical examination will only be granted once the controller has met all eligibility criteria outlined above and has formally requested access.
 

--- a/docs/policies/marketing/banners.md
+++ b/docs/policies/marketing/banners.md
@@ -40,7 +40,7 @@ Through consistent application of these rules, the Arabian vACC demonstrates pro
 
 ## General Guidelines
 ### Title & Logo
-Event titles must be **clear and easy to read**, ensuring members immediately understand what the event is about. The **Arabian vACC logo** must be clearly displayed using the correct variation for the background, and its usage must follow our [branding guidelines](https://library.arabianvacc.com/vacc_documents/marketing/branding/).  
+Event titles must be **clear and easy to read**, ensuring members immediately understand what the event is about. The **Arabian vACC logo** must be clearly displayed using the correct variation for the background, and its usage must follow our [branding guidelines](https://library.vatsim-arabian.com/vacc_documents/marketing/branding/).  
 
 The **VATMENA logo** must also be displayed in accordance with the Division’s marketing guidelines. All logos should be **well-spaced** and presented at the **same size** for consistency and professionalism.
 
@@ -61,7 +61,7 @@ If images are used, ensure you have **permission to use them on behalf of the vA
 ### Controller Examination Banners
 Controller examination banners are subject to **stricter requirements**. Only the **official template** and **approved backgrounds** may be used.  
 
-The **titles and descriptions** of controller examinations must strictly follow the [**policy set by the Marketing Department**](https://library.arabianvacc.com/policies/marketing/examinations/).
+The **titles and descriptions** of controller examinations must strictly follow the [**policy set by the Marketing Department**](https://library.vatsim-arabian.com/policies/marketing/examinations/).
 
 ### Colors
 Please use the **color palette defined in the branding guidelines**. Variations in **shades of the primary colors** are permitted.

--- a/docs/policies/marketing/branding.md
+++ b/docs/policies/marketing/branding.md
@@ -60,8 +60,8 @@ The Arabian vACC uses the **Mulish** font for all official branding and communic
 ### Banners
 For detailed guidelines on banner creation, usage, and specifications, please refer to our separate **Banner Policy**:  
 
-🔗 [View Event Banner Policy](https://library.arabianvacc.com/vacc_documents/marketing/branding/)
-🔗 [View Examination Banner Policy](https://library.arabianvacc.com/vacc_documents/marketing/banners/)
+🔗 [View Event Banner Policy](https://library.vatsim-arabian.com/vacc_documents/marketing/branding/)
+🔗 [View Examination Banner Policy](https://library.vatsim-arabian.com/vacc_documents/marketing/banners/)
 
 ## The thoughts behind the logo
 The logo was designed by **Naman Gaur (1506377)** following the merger of the **Bahrain & Qatar, Emirates, and Muscat vACCs**. It features a modern, clean, and professional design, emphasizing clarity and precision. The design incorporates an oryx, symbolizing the unity of the three countries, and is minimalistic, reinforcing simplicity and elegance. 

--- a/docs/policies/marketing/examinations.md
+++ b/docs/policies/marketing/examinations.md
@@ -61,8 +61,8 @@ Backgrounds must consist of either:
 ## Additional Guidelines
 For more detailed instructions on **banner creation**, please refer to the following guidelines:  
 
-- **Branding Guidelines:** [Arabian vACC Branding](https://library.arabianvacc.com/vacc_documents/marketing/branding/)  
-- **Banner Guidelines:** [Arabian vACC Banners](https://library.arabianvacc.com/vacc_documents/marketing/banners/)  
+- **Branding Guidelines:** [Arabian vACC Branding](https://library.vatsim-arabian.com/vacc_documents/marketing/branding/)  
+- **Banner Guidelines:** [Arabian vACC Banners](https://library.vatsim-arabian.com/vacc_documents/marketing/banners/)  
 
 It is **essential** that these guidelines are followed to ensure consistency and professionalism.
 

--- a/docs/policies/membership/general.md
+++ b/docs/policies/membership/general.md
@@ -58,7 +58,7 @@ A **transferring controller** is defined as a VATSIM member seeking a permanent 
 
 To initiate a transfer request, please refer to the official guide:
 
-👉 [**Joining the Arabian vACC**](https://library.arabianvacc.com/getting_started/joining_arabian/)
+👉 [**Joining the Arabian vACC**](https://library.vatsim-arabian.com/getting_started/joining_arabian/)
 
 This guide outlines the required steps and documentation for a successful transfer application.
 
@@ -74,7 +74,7 @@ A **visiting controller** is a VATSIM member who retains their primary home vACC
 
 Guide link:
 
-👉 [**Applying as a Visiting Controller**](https://library.arabianvacc.com/getting_started/starting_atc_training/)
+👉 [**Applying as a Visiting Controller**](https://library.vatsim-arabian.com/getting_started/starting_atc_training/)
 
 ---
 

--- a/docs/policies/technical/data_protection_policy.md
+++ b/docs/policies/technical/data_protection_policy.md
@@ -40,7 +40,7 @@ death from the misuse of this document.
 This document intends to outline the procedures employed by the Arabian vACC (Arabian vACC) to ensure data protection compliance with EU General Data Protection Regulation.
 
 ## Introduction
-* Arabian vACC refers to the community at https://arabianvacc.com/. (“we”, “us”, “our”, “ourselves”, “the vACC”).
+* Arabian vACC refers to the community at https://vatsim-arabian.com/. (“we”, “us”, “our”, “ourselves”, “the vACC”).
 * VATMENA refers to the parent body of vACCs in the Middle East and North Africa division on VATSIM at http://vatsim.me/.
 * VATSIM refers to the organization at https://www.vatsim.net.
 * Discord refers to Discord at https://discord.com.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,7 @@
 # Project Information
 site_name: Arabian vACC - Library
 site_description: Access essential tools and information for pilots and controllers in the Arabian vACC. From charts and procedures to training and sector files, everything you need for a seamless and realistic experience on the VATSIM network is here.
-site_url: https://library.arabian-vacc.com
+site_url: https://library.vatsim-arabian.com
 repo_url: https://github.com/arabian-vacc/library
 repo_name: arabian-vacc/library
 edit_uri: ""


### PR DESCRIPTION
Fixes links from the previous website "https://arabianvacc.com/" to new website "https://vatsim-arabian.com/"
Updated track audio download link to reflect the latest version as of 3/31/2026
Updated CNAME